### PR TITLE
Upgrade manifest.json to MV3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,10 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Analog",
   "description": "Replace your new tab page with a minimal analog clock.",
-  "version": "0.1.1",
-  "browser_action": {
+  "version": "0.1.2",
+  "author": "Cole Bemis <cole@colebemis.com> (colebemis.com)",
+  "action": {
     "default_icon": {
       "16": "./icons/icon-16.png",
       "32": "./icons/icon-32.png"
@@ -17,8 +18,8 @@
     "128": "./icons/icon-128.png",
     "256": "./icons/icon-256.png"
   },
-  "chrome_url_overrides" : {
+  "chrome_url_overrides": {
     "newtab": "index.html"
   },
-  "author": "Cole Bemis <cole@colebemis.com> (colebemis.com)"
+  "permissions": []
 }


### PR DESCRIPTION
This PR migrates the Chrome extension from Manifest V2 to V3, to be compliant with Chrome Web Store requirements.

- Changed "manifest_version" to 3  
- Rename "browser_action" block to "action"  
- Add an explicit (empty) "permissions" array  
- Manifest 3 doesn't support author field, but I kept anyway and tested still working.  I think Chrome ignores the field.
